### PR TITLE
feat: Implement-sign-in-out-view

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -9,6 +9,8 @@ import {
   onAuthStateChanged,
 } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js";
 
+import { showAppView, showLogInView } from "./ui.js";
+
 export async function signInWithGitHub() {
   const provider = new GithubAuthProvider();
   try {
@@ -31,6 +33,7 @@ export function setupAuthListeners() {
   onAuthStateChanged(auth, (user) => {
     if (user) {
       // User is signed in, log to console
+      showAppView();
       console.log(
         "Auth state changed - User is now logged in.",
         user.displayName,
@@ -38,6 +41,7 @@ export function setupAuthListeners() {
       );
     } else {
       // User is not signed in, log to console
+      showLogInView();
       console.log("Auth state changed - No user is logged in.");
     }
   });

--- a/js/ui.js
+++ b/js/ui.js
@@ -6,13 +6,27 @@ import { signInWithGitHub, logout } from "./auth.js";
 // Setup Button Event Listeners (Placeholder - backend-test.html)
 
 export function setupUIEventListeners() {
-  const testLoginBtn = document.getElementById("test-login-button");
+  const testLoginBtn = document.getElementById("login-button");
   if (testLoginBtn) {
     testLoginBtn.addEventListener("click", signInWithGitHub);
   }
 
-  const testLogoutBtn = document.getElementById("test-logout-button");
+  const testLogoutBtn = document.getElementById("logout-button");
   if (testLogoutBtn) {
     testLogoutBtn.addEventListener("click", logout);
   }
+}
+
+export function showAppView() {
+  const login = (document.getElementById("login-section").style.display =
+    "none");
+  const appSect = (document.getElementById("app-section").style.display =
+    "block");
+}
+
+export function showLogInView() {
+  const login = (document.getElementById("login-section").style.display =
+    "block");
+  const appSect = (document.getElementById("app-section").style.display =
+    "none");
 }


### PR DESCRIPTION
- [x] On successful sign-in, the main project board should be displayed.
- [x] On sign-out, the user should be returned to the login page.

I forgot to implement how the login page / main project board are displayed when signing in/out that was needed from the previous issue #2. 


Closes #2 

Author's Checklist

Before submitting this pull request, please make sure you have checked the following:

[x] My code follows the project's style guidelines.

[x] I have performed a self-review of my own code.

[x] I have commented my code, particularly in hard-to-understand areas.

[x] My changes generate no new warnings or errors in the console.

[x] I have tested my changes and they work as expected.

[x] I have assigned myself to this pull request.