### PR TITLE
feat: Implement drag-and-drop for tasks (Closes #10)

### DIFF
--- a/js/firestore.js
+++ b/js/firestore.js
@@ -5,6 +5,8 @@ import {
   collection,
   addDoc,
   onSnapshot,
+  doc,
+  updateDoc,
 } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js";
 import { db } from "./firebase.js";
 
@@ -39,4 +41,10 @@ export function setupFirestoreListeners() {
     }
     renderTasks(tasksList);
   });
+}
+
+// Update Task Status - Firestore
+export async function updateTaskStatus(taskId, newStatus) {
+  const taskRef = doc(db, "tasks", taskId);
+  updateDoc(taskRef, { status: newStatus });
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -2,7 +2,7 @@
 
 // Import Functions
 import { signInWithGitHub, logout } from "./auth.js";
-import { addTask } from "./firestore.js";
+import { addTask, updateTaskStatus } from "./firestore.js";
 
 // Setup Button Event Listeners (Placeholder - backend-test.html)
 
@@ -53,6 +53,7 @@ export function renderTasks(tasks) {
   tasks.forEach((task) => {
     const cardElement = document.createElement("div");
     cardElement.className = "task-card";
+    cardElement.dataset.id = task.id;
 
     const titleElement = document.createElement("h3");
     titleElement.textContent = task.title;
@@ -77,3 +78,66 @@ export function renderTasks(tasks) {
     }
   });
 }
+
+// Drag and Drop Functionality
+
+const todoColumn = document.getElementById("todo-card-container");
+const ongoingColumn = document.getElementById("ongoing-card-container");
+const completedColumn = document.getElementById("completed-card-container");
+
+// To-Do Column Drag/Drop
+new Sortable(todoColumn, {
+  group: "shared",
+  onEnd: function (event) {
+    const taskId = event.item.dataset.id;
+    let newStatus = "";
+    if (event.to.id === "todo-card-container") {
+      newStatus = "todo";
+    } else if (event.to.id === "ongoing-card-container") {
+      newStatus = "ongoing";
+    } else if (event.to.id === "completed-card-container") {
+      newStatus = "completed";
+    }
+    if (newStatus) {
+      updateTaskStatus(taskId, newStatus);
+    }
+  },
+});
+
+// Ongoing Drag/Drop
+new Sortable(ongoingColumn, {
+  group: "shared",
+  onEnd: function (event) {
+    const taskId = event.item.dataset.id;
+    let newStatus = "";
+    if (event.to.id === "todo-card-container") {
+      newStatus = "todo";
+    } else if (event.to.id === "ongoing-card-container") {
+      newStatus = "ongoing";
+    } else if (event.to.id === "completed-card-container") {
+      newStatus = "completed";
+    }
+    if (newStatus) {
+      updateTaskStatus(taskId, newStatus);
+    }
+  },
+});
+
+// Completed Drag/Drop
+new Sortable(completedColumn, {
+  group: "shared",
+  onEnd: function (event) {
+    const taskId = event.item.dataset.id;
+    let newStatus = "";
+    if (event.to.id === "todo-card-container") {
+      newStatus = "todo";
+    } else if (event.to.id === "ongoing-card-container") {
+      newStatus = "ongoing";
+    } else if (event.to.id === "completed-card-container") {
+      newStatus = "completed";
+    }
+    if (newStatus) {
+      updateTaskStatus(taskId, newStatus);
+    }
+  },
+});


### PR DESCRIPTION
- [x] Implement the ability for users to drag a task card from one column to another.
- [x] When a card is dropped in a new column, its status field in Firestore must be updated accordingly.
- [x] Used SortableJS library to implent Drag/Drop


Closes #10 

Author's Checklist

Before submitting this pull request, please make sure you have checked the following:

[x] My code follows the project's style guidelines.

[x] I have performed a self-review of my own code.

[x] I have commented my code, particularly in hard-to-understand areas.

[x] My changes generate no new warnings or errors in the console.

[x] I have tested my changes and they work as expected.

[x] I have assigned myself to this pull request.